### PR TITLE
feat: support local llama.cpp endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 export OPENAI_MODEL="qwen/qwen3-coder:free"
 ```
 
+**Option 3: Local Llama.cpp Server**
+
+Run a local `llama.cpp` server with OpenAI compatibility and point the CLI at it:
+
+```bash
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+export OPENAI_MODEL="your-model-name"
+# No OPENAI_API_KEY needed for local servers
+```
+
 </details>
 
 ## Usage Examples

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -125,7 +125,7 @@ The CLI will automatically detect if it is running in a non-interactive terminal
 OpenAI-compatible API method if configured:
 
 1.  **OpenAI-Compatible API:**
-    - Set the `OPENAI_API_KEY` environment variable.
+    - Set the `OPENAI_API_KEY` environment variable. (Optional for local servers like `llama.cpp`.)
     - Optionally set `OPENAI_BASE_URL` and `OPENAI_MODEL` for custom endpoints.
     - The CLI will use these credentials to authenticate with the API provider.
 

--- a/docs/cli/openai-auth.md
+++ b/docs/cli/openai-auth.md
@@ -64,6 +64,15 @@ You can use custom endpoints by setting the `OPENAI_BASE_URL` environment variab
 - Using other OpenAI-compatible APIs
 - Using local OpenAI-compatible servers
 
+### Using a local `llama.cpp` server
+
+If you're running a `llama.cpp` server with OpenAI-compatible APIs, no API key is required. Configure the CLI like this:
+
+```bash
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+export OPENAI_MODEL="your-model-name"
+```
+
 ## Switching Authentication Methods
 
 To switch between authentication methods, use the `/auth` command in the CLI interface.

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -40,7 +40,11 @@ export const validateAuthMethod = (authMethod: string): string | null => {
 
   if (authMethod === AuthType.USE_OPENAI) {
     if (!process.env.OPENAI_API_KEY) {
-      return 'OPENAI_API_KEY environment variable not found. You can enter it interactively or add it to your .env file.';
+      const baseUrl = process.env.OPENAI_BASE_URL || '';
+      const isLocal = baseUrl.includes('localhost') || baseUrl.includes('127.0.0.1');
+      if (!isLocal) {
+        return 'OPENAI_API_KEY environment variable not found. You can enter it interactively or add it to your .env file.';
+      }
     }
     return null;
   }

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -17,6 +17,7 @@ describe('validateNonInterActiveAuth', () => {
   let originalEnvVertexAi: string | undefined;
   let originalEnvGcp: string | undefined;
   let originalEnvOpenAiApiKey: string | undefined;
+  let originalEnvOpenAiBaseUrl: string | undefined;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let processExitSpy: ReturnType<typeof vi.spyOn>;
   let refreshAuthMock: jest.MockedFunction<
@@ -28,10 +29,12 @@ describe('validateNonInterActiveAuth', () => {
     originalEnvVertexAi = process.env.GOOGLE_GENAI_USE_VERTEXAI;
     originalEnvGcp = process.env.GOOGLE_GENAI_USE_GCA;
     originalEnvOpenAiApiKey = process.env.OPENAI_API_KEY;
+    originalEnvOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_GENAI_USE_VERTEXAI;
     delete process.env.GOOGLE_GENAI_USE_GCA;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     processExitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`process.exit(${code}) called`);
@@ -59,6 +62,11 @@ describe('validateNonInterActiveAuth', () => {
       process.env.OPENAI_API_KEY = originalEnvOpenAiApiKey;
     } else {
       delete process.env.OPENAI_API_KEY;
+    }
+    if (originalEnvOpenAiBaseUrl !== undefined) {
+      process.env.OPENAI_BASE_URL = originalEnvOpenAiBaseUrl;
+    } else {
+      delete process.env.OPENAI_BASE_URL;
     }
     vi.restoreAllMocks();
   });
@@ -111,6 +119,19 @@ describe('validateNonInterActiveAuth', () => {
 
   it('uses USE_OPENAI if OPENAI_API_KEY is set', async () => {
     process.env.OPENAI_API_KEY = 'fake-openai-key';
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
+    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_OPENAI);
+  });
+
+  it('uses USE_OPENAI if OPENAI_BASE_URL is set', async () => {
+    process.env.OPENAI_BASE_URL = 'http://localhost:8080/v1';
     const nonInteractiveConfig: NonInteractiveConfig = {
       refreshAuth: refreshAuthMock,
     };

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -18,7 +18,7 @@ function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env.GEMINI_API_KEY) {
     return AuthType.USE_GEMINI;
   }
-  if (process.env.OPENAI_API_KEY) {
+  if (process.env.OPENAI_API_KEY || process.env.OPENAI_BASE_URL) {
     return AuthType.USE_OPENAI;
   }
   if (process.env.QWEN_OAUTH_TOKEN) {
@@ -36,7 +36,7 @@ export async function validateNonInteractiveAuth(
 
   if (!effectiveAuthType) {
     console.error(
-      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, OPENAI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA`,
+      `Please set an Auth method in your ${USER_SETTINGS_PATH} or specify one of the following environment variables before running: GEMINI_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA`,
     );
     process.exit(1);
   }

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -181,17 +181,16 @@ export async function createContentGenerator(
   }
 
   if (config.authType === AuthType.USE_OPENAI) {
-    if (!config.apiKey) {
-      throw new Error('OpenAI API key is required');
-    }
-
     // Import OpenAIContentGenerator dynamically to avoid circular dependencies
     const { OpenAIContentGenerator } = await import(
       './openaiContentGenerator.js'
     );
 
+    // Allow local OpenAI-compatible endpoints (like llama.cpp) without an API key
+    const apiKey = config.apiKey || 'no-api-key';
+
     // Always use OpenAIContentGenerator, logging is controlled by enableOpenAILogging flag
-    return new OpenAIContentGenerator(config.apiKey, config.model, gcConfig);
+    return new OpenAIContentGenerator(apiKey, config.model, gcConfig);
   }
 
   if (config.authType === AuthType.QWEN_OAUTH) {


### PR DESCRIPTION
## Summary
- allow OpenAI content generator to run without API key for local llama.cpp servers
- treat OPENAI_BASE_URL as OpenAI auth and skip key requirement when pointing to localhost
- document how to run against a local llama.cpp server

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@qwen-code/qwen-code-core")*


------
https://chatgpt.com/codex/tasks/task_e_6896c7eb9638832699881e8ae449133f