### PR TITLE
Force non-streaming for local llama.cpp requests

### DIFF
--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -81,6 +81,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
   protected client: OpenAI;
   private model: string;
   private config: Config;
+  private baseURL: string;
   private streamingToolCalls: Map<
     number,
     {
@@ -94,6 +95,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     this.model = model;
     this.config = config;
     const baseURL = process.env.OPENAI_BASE_URL || '';
+    this.baseURL = baseURL;
 
     // Configure timeout settings - using progressive timeouts
     const timeoutConfig = {
@@ -205,6 +207,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         model: this.model,
         messages,
         ...samplingParams,
+        stream: false,
         metadata: {
           sessionId: this.config.getSessionId?.(),
           promptId: userPromptId,
@@ -324,6 +327,19 @@ export class OpenAIContentGenerator implements ContentGenerator {
     request: GenerateContentParameters,
     userPromptId: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    // llama.cpp's OpenAI-compatible server doesn't support tool use with streaming
+    // responses. When targeting a local llama.cpp instance (detected via base URL),
+    // force non-streaming behavior and wrap the result in an async generator.
+    const needsNoStream =
+      this.baseURL.includes('localhost') || this.baseURL.includes('127.0.0.1');
+    if (needsNoStream) {
+      const response = await this.generateContent(request, userPromptId);
+      async function* wrapped() {
+        yield response;
+      }
+      return wrapped();
+    }
+
     const startTime = Date.now();
     const messages = this.convertToOpenAIFormat(request);
 


### PR DESCRIPTION
## Summary
- Always set `stream: false` when calling OpenAI chat completions
- Detect local llama.cpp endpoint and disable streaming, wrapping responses in an async generator

## Testing
- `npm test` (fails: src/tools/edit.test.ts > EditTool > Error Scenarios > should return FILE_WRITE_FAILURE on write error)

------
https://chatgpt.com/codex/tasks/task_e_6898d04524a883268fa268e0862fc554